### PR TITLE
Fixing kublet problem

### DIFF
--- a/ansible/roles/eks/kubelet.yml
+++ b/ansible/roles/eks/kubelet.yml
@@ -1,0 +1,111 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+# file: ansible/roles/eks/tasks/kubelet.yml
+
+- name: be sure the kubelet folders exists
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - /etc/kubernetes/manifests
+    - /var/lib/kubernetes
+    - /var/lib/kubelet
+    - /etc/kubernetes/kubelet
+    - /etc/systemd/system/kubelet.service.d
+
+- name: be sure we have the kubernetes dependencies installed
+  yum:
+    state: latest
+    name:
+      - conntrack-tools
+      - ebtables
+      - socat
+      - nfs-utils
+  when: ansible_facts['os_family'] == "RedHat"
+
+- name: be sure we have the kubernetes dependencies installed
+  apt:
+    state: latest
+    name:
+      - apt-transport-https
+      - curl
+      - socat
+      - jq
+  when: ansible_facts['os_family'] == "Debian"
+
+- name: be sure we have nfs-common installed to mount efs mounts
+  apt:
+    state: latest
+    name: nfs-common
+  when: ansible_facts['distribution'] == "Ubuntu"
+
+- name: be sure we have nfs-utils installed to mount efs mounts
+  apt:
+    state: latest
+    name: nfs-utils
+  when: ansible_facts['distribution'] == "Debian"
+
+- name: be sure we have the latest version of the kubelet from aws
+  get_url:
+    url: "{{ eks_s3_bucket_url }}/{{ k8s_version }}/{{ k8s_build_date }}/bin/linux/{{ kube_arch }}/kubelet"
+    dest: /usr/bin/kubelet
+    mode: a+x
+
+- name: be sure the latest version of kubeconfig is present
+  get_url:
+    url: https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/files/kubelet-kubeconfig
+    dest: /var/lib/kubelet/kubeconfig
+
+- name: be sure the latest version of kubelet configuration is present
+  get_url:
+    url: https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/files/kubelet-config.json
+    dest: /etc/kubernetes/kubelet/kubelet-config.json
+
+- name: be sure the latest version of kubelet service is present
+  get_url:
+    url: https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/files/kubelet.service
+    dest: /etc/systemd/system/kubelet.service
+
+- name: be sure the kernel is configured for kubernetes
+  block:
+    - command: modprobe br_netfilter
+    - lineinfile:
+        path: /etc/sysctl.d/99-k8s.conf
+        line: 'net.ipv4.ip_forward = 1'
+        state: present
+        create: yes
+    - lineinfile:
+        path: /etc/sysctl.d/99-k8s.conf
+        line: 'net.bridge.bridge-nf-call-ip6tables = 1'
+        state: present
+        create: yes
+    - lineinfile:
+        path: /etc/sysctl.d/99-k8s.conf
+        line: 'net.bridge.bridge-nf-call-iptables = 1'
+        state: present
+        create: yes
+#Adding these 3 lines to make the kubelet not fail on the startup and create a kernel panic
+    - lineinfile:
+        path: /etc/sysctl.d/90-kubelet.conf
+        line: 'vm.overcommit_memory=1'
+        state: present
+        create: yes
+    - lineinfile:
+        path: /etc/sysctl.d/90-kubelet.conf
+        line: 'kernel.panic=10'
+        state: present
+        create: yes
+    - lineinfile:
+        path: /etc/sysctl.d/90-kubelet.conf
+        line: 'kernel.panic_on_oops=1'
+        state: present
+        create: yes
+    - command: sysctl --system
+
+- name: be sure the kubelet is started and enabled
+  systemd:
+    name: kubelet
+    state: stopped
+    enabled: no
+    daemon_reload: yes


### PR DESCRIPTION
*Issue #, if available:*
Kublet doesn't start when the image is built and the instance started , creates a kernel panic 

Jun 10 12:19:18  kubelet: I0610 12:19:18.382531    8820 kubelet.go:1844] skipping pod synchronization - container runtime status check may not have completed yet
Jun 10 12:19:18  kubelet: E0610 12:19:18.397158    8820 kubelet.go:2272] node ".eu-west-1.compute.internal" not found
Jun 10 12:19:18  kubelet: I0610 12:19:18.425502    8820 cpu_manager.go:161] [cpumanager] starting with none policy
Jun 10 12:19:18  kubelet: I0610 12:19:18.425520    8820 cpu_manager.go:162] [cpumanager] reconciling every 10s
Jun 10 12:19:18  kubelet: I0610 12:19:18.425530    8820 policy_none.go:42] [cpumanager] none policy: Start
Jun 10 12:19:18  kubelet: F0610 12:19:18.426052    8820 kubelet.go:1385] Failed to start ContainerManager [invalid kernel flag: vm/overcommit_memory, expected value: 1, actual value: 0, invalid kernel flag: kernel/panic, expected value: 10, actual value: 0]
Jun 10 12:19:18  systemd: kubelet.service: main process exited, code=exited, status=255/n/a
Jun 10 12:19:18  systemd: Unit kubelet.service entered failed state.
Jun 10 12:19:18  systemd: kubelet.service failed.
Jun 10 12:19:23  systemd: kubelet.service holdoff time over, scheduling restart.
Jun 10 12:19:23  systemd: Stopped Kubernetes Kubelet.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
