### PR TITLE
al2: Reduce size of base image.

### DIFF
--- a/amazon-eks-node-al2.json
+++ b/amazon-eks-node-al2.json
@@ -3,7 +3,7 @@
     "aws_region":"us-east-2",
     "ami_description":"EKS Kubernetes Worker AMI on AmazonLinux2 image (k8s: {{user `eks_version`}})",
     "eks_version":"1.18",
-    "volume_size":"100",
+    "volume_size":"10",
     "vpc_id":"",
     "subnet_id":"",
     "http_proxy": "",
@@ -41,8 +41,8 @@
       "subnet_id":"{{user `subnet_id`}}",
       "launch_block_device_mappings":[
         {
-          "device_name":"/dev/sda1",
-          "volume_size":25,
+          "device_name":"/dev/xvda",
+          "volume_size":4,
           "volume_type":"gp2",
           "delete_on_termination":true
         },
@@ -54,6 +54,12 @@
         }
       ],
       "ami_block_device_mappings":[
+        {
+          "device_name":"/dev/xvda",
+          "volume_size":4,
+          "volume_type":"gp2",
+          "delete_on_termination":true
+        },
         {
           "device_name":"/dev/sdb",
           "volume_size":"{{user `volume_size`}}",

--- a/scripts/al2/boilerplate.sh
+++ b/scripts/al2/boilerplate.sh
@@ -17,7 +17,7 @@ yum install -y parted system-lsb-core
 amazon-linux-extras install epel -y
 
 echo "ensure secondary disk is mounted to proper locations"
-partition_disks /dev/nvme2n1
+partition_disks /dev/nvme1n1
 
 echo "configuring /etc/environment"
 configure_http_proxy


### PR DESCRIPTION
*Description of changes:*
This causes the AMI to not expand the root partition from 4GiB to 25GiB
when most of that space will not be used. Additionally, adding the root
disk to `ami_block_device_mappings` seems to prevent an additional
unnecessary volume from being created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
