### PR TITLE
al2: Unconditionally disable kernel modules.

### DIFF
--- a/scripts/al2/cis-benchmark.sh
+++ b/scripts/al2/cis-benchmark.sh
@@ -15,10 +15,9 @@ tmpfs_and_mount() {
 unload_module() {
   local fsname=$1
 
-  if rmmod ${fsname}; then
-    mkdir -p /etc/modprobe.d/
-    echo "install ${fsname} /bin/true" > /etc/modprobe.d/${fsname}.conf
-  fi
+  rmmod "${fsname}" || true
+  mkdir -p /etc/modprobe.d/
+  echo "install ${fsname} /bin/true" > "/etc/modprobe.d/${fsname}.conf"
 }
 
 systemd_disable() {


### PR DESCRIPTION
*Description of changes:*
Just because the kernel module is not loaded at the time of AMI creation
does not alleviate the need for configuring the modprobe rule.

By adding this change, Amazon Inspector will successfully pass the CIS
Benchmark controls related to disabling specific kernel modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
