### PR TITLE
al2: Write auditd rules to auditd.d/cis.rules file.

### DIFF
--- a/scripts/al2/cis-benchmark.sh
+++ b/scripts/al2/cis-benchmark.sh
@@ -368,83 +368,83 @@ sed -i 's/^\(GRUB_CMDLINE_LINUX_DEFAULT=.*\)"$/\1 audit=1"/' /etc/default/grub
 grub2-mkconfig -o /etc/grub2.cfg
 
 echo "4.1.4 - ensure events that modify date and time information are collected"
-echo "-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S clock_settime -k time-change" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S clock_settime -k time-change" >> /etc/audit/audit.rules
-echo "-w /etc/localtime -p wa -k time-change" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b64 -S clock_settime -k time-change" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S clock_settime -k time-change" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/localtime -p wa -k time-change" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.5 - ensure events that modify user/group information are collected"
-echo "-w /etc/group -p wa -k identity" >> /etc/audit/audit.rules
-echo "-w /etc/passwd -p wa -k identity" >> /etc/audit/audit.rules
-echo "-w /etc/gshadow -p wa -k identity" >> /etc/audit/audit.rules
-echo "-w /etc/shadow -p wa -k identity" >> /etc/audit/audit.rules
-echo "-w /etc/security/opasswd -p wa -k identity" >> /etc/audit/audit.rules
+echo "-w /etc/group -p wa -k identity" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/passwd -p wa -k identity" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/gshadow -p wa -k identity" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/shadow -p wa -k identity" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/security/opasswd -p wa -k identity" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.6 - ensure events that modify the system's network environment are collected"
-echo "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale" >> /etc/audit/audit.rules
-echo "-w /etc/issue -p wa -k system-locale" >> /etc/audit/audit.rules
-echo "-w /etc/issue.net -p wa -k system-locale" >> /etc/audit/audit.rules
-echo "-w /etc/hosts -p wa -k system-locale" >> /etc/audit/audit.rules
-echo "-w /etc/sysconfig/network -p wa -k system-locale" >> /etc/audit/audit.rules
-echo "-w /etc/sysconfig/network-scripts/ -p wa -k system-locale" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/issue -p wa -k system-locale" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/issue.net -p wa -k system-locale" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/hosts -p wa -k system-locale" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/sysconfig/network -p wa -k system-locale" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/sysconfig/network-scripts/ -p wa -k system-locale" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.6 - ensure events that modify the system's network environment are collected"
-echo "-w /etc/selinux/ -p wa -k MAC-policy" >> /etc/audit/audit.rules
-echo "-w /usr/share/selinux/ -p wa -k MAC-policy" >> /etc/audit/audit.rules
+echo "-w /etc/selinux/ -p wa -k MAC-policy" >> /etc/audit/rules.d/cis.rules
+echo "-w /usr/share/selinux/ -p wa -k MAC-policy" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.8 - ensure login and logout events are collected"
-echo "-w /var/log/lastlog -p wa -k logins" >> /etc/audit/audit.rules
-echo "-w /var/run/faillock/ -p wa -k logins" >> /etc/audit/audit.rules
+echo "-w /var/log/lastlog -p wa -k logins" >> /etc/audit/rules.d/cis.rules
+echo "-w /var/run/faillock/ -p wa -k logins" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.9 - ensure session initiation information is collected"
-echo "-w /var/run/utmp -p wa -k session" >> /etc/audit/audit.rules
-echo "-w /var/log/wtmp -p wa -k logins" >> /etc/audit/audit.rules
-echo "-w /var/log/btmp -p wa -k logins" >> /etc/audit/audit.rules
+echo "-w /var/run/utmp -p wa -k session" >> /etc/audit/rules.d/cis.rules
+echo "-w /var/log/wtmp -p wa -k logins" >> /etc/audit/rules.d/cis.rules
+echo "-w /var/log/btmp -p wa -k logins" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.10 - ensure discretionary access control permission modification events are collected"
-echo "-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.11 - ensure unsuccessful unauthorized file access attempts are collected"
-echo "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.12 - ensure use of privileged commands is collected"
 find / -xdev \( -perm -4000 -o -perm -2000 \) -type f | awk '{print \
 "-a always,exit -F path=" $1 " -F perm=x -F auid>=1000 -F auid!=4294967295 \
--k privileged" }' >> /etc/audit/audit.rules
+-k privileged" }' >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.13 - ensure successful file system mounts are collected"
-echo "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.14 - ensure file deletion events by users are collected"
-echo "-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.15 - ensure changes to system administration scope (sudoers) is collected"
-echo "-w /etc/sudoers -p wa -k scope" >> /etc/audit/audit.rules
-echo "-w /etc/sudoers.d/ -p wa -k scope" >> /etc/audit/audit.rules
+echo "-w /etc/sudoers -p wa -k scope" >> /etc/audit/rules.d/cis.rules
+echo "-w /etc/sudoers.d/ -p wa -k scope" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.16 - ensure system administrator actions (sudolog) are collected"
-echo "-w /var/log/sudo.log -p wa -k actions" >> /etc/audit/audit.rules
+echo "-w /var/log/sudo.log -p wa -k actions" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.17 - ensure kernel module loading and unloading is collected"
-echo "-w /sbin/insmod -p x -k modules" >> /etc/audit/audit.rules
-echo "-w /sbin/rmmod -p x -k modules" >> /etc/audit/audit.rules
-echo "-w /sbin/modprobe -p x -k modules" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S init_module -S delete_module -k modules" >> /etc/audit/audit.rules
+echo "-w /sbin/insmod -p x -k modules" >> /etc/audit/rules.d/cis.rules
+echo "-w /sbin/rmmod -p x -k modules" >> /etc/audit/rules.d/cis.rules
+echo "-w /sbin/modprobe -p x -k modules" >> /etc/audit/rules.d/cis.rules
+echo "-a always,exit -F arch=b64 -S init_module -S delete_module -k modules" >> /etc/audit/rules.d/cis.rules
 
 echo "4.1.18 - ensure the audit configuration is immutable"
-echo "-e 2" >> /etc/audit/audit.rules
+echo "-e 2" >> /etc/audit/rules.d/cis.rules
 
 echo "4.2.1.1 - ensure rsyslog Service is enabled"
 yum install -y rsyslog


### PR DESCRIPTION
*Description of changes:*

On start of the audit subsystem, systemd will run `/sbin/augenrules`
which overwrites the contents of `/etc/audit/audit.rules` in effect
removing all of the audit rules being added by the scripts.

By adding this change, Amazon Inspector will successfully pass the CIS
Benchmark controls related to having the correct audit rules in place.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
