### PR TITLE
al2: Fix benchmark 5.4.4 (umask) to pass Amazon Inspector.

### DIFF
--- a/scripts/al2/cis-benchmark.sh
+++ b/scripts/al2/cis-benchmark.sh
@@ -688,6 +688,10 @@ grep "^root:" /etc/passwd | cut -f4 -d:
 echo "5.4.4 - ensure default user umask is 027 or more restrictive"
 echo "umask 027" >> /etc/bashrc
 echo "umask 027" >> /etc/profile
+# Just adding the umask isn't enough, all existing entries need to be fixed as
+# well.
+sed -i -e 's/\bumask\s\+\(002\|022\)/umask 027/' \
+  /etc/bashrc /etc/profile /etc/profile.d/*.sh
 
 echo "5.4.5 - ensure default user shell timeout is 900 seconds or less"
 echo "TMOUT=600" >> /etc/bashrc


### PR DESCRIPTION
*Description of changes:*

Even though inspection of `/etc/profile` and `/etc/bashrc` allow it to
be obvious that control flow passes over the umask lines added to the
end of the file, both the CIS Benchmark scoring instructions as well as
Amazon Inspector require that every `umask` present in the relevant
files are updated.

By adding this change, Amazon Inspector will successfully pass the CIS
Benchmark controls related to having correctly restricted the umask.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
