### PR TITLE
al2: Correctly override motd banner (1.7.1.1).

### DIFF
--- a/scripts/al2/cis-benchmark.sh
+++ b/scripts/al2/cis-benchmark.sh
@@ -196,7 +196,9 @@ yum_remove prelink
 
 echo "1.7.1.1 - ensure message of the day is configured properly"
 rm -f /etc/cron.d/update-motd
-cat > /etc/motd <<EOF
+cat > /etc/update-motd.d/30-banner <<"OUTEREOF"
+#!/bin/sh
+cat <<"EOF"
 You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
 
 By using this IS (which includes any device attached to this IS), you consent to the following conditions:
@@ -206,6 +208,7 @@ By using this IS (which includes any device attached to this IS), you consent to
 -This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
 -Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.
 EOF
+OUTEREOF
 
 echo "1.7.1.2 - ensure local login warning banner is configured properly"
 cat > /etc/issue <<EOF


### PR DESCRIPTION
*Description of changes:*

While the `update-motd` cron was removed, there is a systemd unit that
executes on VM start which re-computes the motd file and replaces the
contents. Instead of disabling this systemd unit, we instead replace the
contents of the script which is used for generating the motd.

By adding this change, Amazon Inspector will successfully pass the CIS
Benchmark controls related to having correctly set `/etc/motd`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
