### PR TITLE
cloud-init: Use built in command to wait for init completion.

### DIFF
--- a/files/functions.sh
+++ b/files/functions.sh
@@ -12,10 +12,7 @@
 #   0 finishes when the cloud-init process is complete
 ################################################################
 wait_for_cloudinit() {
-    while [ ! -f /var/lib/cloud/instance/boot-finished ]; do 
-        echo 'waiting for cloud-init to finish running...'
-        sleep 5 
-    done
+    cloud-init status --wait
 }
 
 get_arch() {


### PR DESCRIPTION
*Description of changes:*

Rather than implementing manual polling for the completion of the
cloud-init process, make use of the built in `status --wait` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
