### PR TITLE
RHEL : Fixed the test to check if the "Release" is Red Hat Enterprise…

### DIFF
--- a/files/functions.sh
+++ b/files/functions.sh
@@ -141,7 +141,7 @@ is_rhel() {
 #   1 - false
 ################################################################
 is_rhel_7() {
-    [[ $(lsb_release -sd) == "\"Red Hat Enterprise Linux release 7"* ]]
+    [[ $(lsb_release -sd) == "\"Red Hat Enterprise Linux release 7"* || "\"Red Hat Enterprise Linux Server release 7"* ]]
 }
 
 ################################################################


### PR DESCRIPTION
… Linux 7

Few RHEL "Release" name contain "server" word. The commit will fix the below Error.

### Error 
    amazon-ebs: ++ get_arch
    amazon-ebs: +++ uname -m
    amazon-ebs: ++ local machine_arch=x86_64
    amazon-ebs: ++ '[' x86_64 == x86_64 ']'
    amazon-ebs: ++ echo amd64
    amazon-ebs: + ARCH=amd64
    amazon-ebs: + is_rhel
    amazon-ebs: ++ lsb_release -sd
    amazon-ebs: + [[ "Red Hat Enterprise Linux Server release 7.9 (Maipo)" == \"\R\e\d\ \H\a\t* ]]
    amazon-ebs: + is_rhel_7
    amazon-ebs: ++ lsb_release -sd
    amazon-ebs: + [[ "Red Hat Enterprise Linux Server release 7.9 (Maipo)" == \"\R\e\d\ \H\a\t\ \E\n\t\e\r\p\r\i\s\e\ \L\i\n\u\x\ \r\e\l\e\a\s\e\ \7* ]]
    amazon-ebs: + is_centos
    amazon-ebs: ++ lsb_release -sd
    amazon-ebs: + [[ "Red Hat Enterprise Linux Server release 7.9 (Maipo)" == \"\C\e\n\t\O\S* ]]
    amazon-ebs: + is_rhel
    amazon-ebs: ++ lsb_release -sd
    amazon-ebs: + [[ "Red Hat Enterprise Linux Server release 7.9 (Maipo)" == \"\R\e\d\ \H\a\t* ]]
    amazon-ebs: + is_rhel_8
    amazon-ebs: ++ lsb_release -sd
    amazon-ebs: + [[ "Red Hat Enterprise Linux Server release 7.9 (Maipo)" == \"\R\e\d\ \H\a\t\ \E\n\t\e\r\p\r\i\s\e\ \L\i\n\u\x\ \r\e\l\e\a\s\e\ \8* ]]
    amazon-ebs: + is_centos
    amazon-ebs: ++ lsb_release -sd
    amazon-ebs: + [[ "Red Hat Enterprise Linux Server release 7.9 (Maipo)" == \"\C\e\n\t\O\S* ]]
    amazon-ebs: + is_ubuntu
    amazon-ebs: ++ lsb_release -sd
    amazon-ebs: + [[ "Red Hat Enterprise Linux Server release 7.9 (Maipo)" == \U\b\u\n\t\u* ]]
    amazon-ebs: + echo 'could not install docker, operating system not found!'
    amazon-ebs: could not install docker, operating system not found!
    amazon-ebs: + exit 1
==> amazon-ebs: Provisioning step had errors: Running the cleanup provisioner, if present...
==> amazon-ebs: Terminating the source AWS instance...
==> amazon-ebs: Cleaning up any extra volumes...
==> amazon-ebs: No volumes to clean up, skipping
==> amazon-ebs: Deleting temporary security group...
==> amazon-ebs: Deleting temporary keypair...
Build 'amazon-ebs' errored after 7 minutes 7 seconds: Script exited with non-zero exit status: 1.Allowed exit codes are: [0]

==> Wait completed after 7 minutes 7 seconds

==> Some builds didn't complete successfully and had errors:
--> amazon-ebs: Script exited with non-zero exit status: 1.Allowed exit codes are: [0]

==> Builds finished but no artifacts were created.
make[1]: *** [build] Error 1
make[1]: Leaving directory `/home/ec2-user/environment/amazon-eks-custom-amis'
make: *** [build-rhel7-1.18] Error 2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
