### PR TITLE
Fix issue #36 and expose the source_ami_owner variable to the make fi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-PACKER_VARIABLES := binary_bucket_name binary_bucket_region eks_version eks_build_date cni_plugin_version root_volume_size data_volume_size hardening_flag http_proxy https_proxy no_proxy
+PACKER_VARIABLES := binary_bucket_name binary_bucket_region eks_version eks_build_date cni_plugin_version root_volume_size data_volume_size hardening_flag http_proxy https_proxy no_proxy source_ami_owner
 VPC_ID := vpc-0e8cf1ce122b1b059
 SUBNET_ID := subnet-0eddf1d7d0f9f9772
 AWS_REGION := us-east-2

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ make build-<operating system>-<eks major version>
 | `root_volume_size` | `10` | The size of the root volume on the host. |
 | `data_volume_size` | `50` | The size of the data volume that is attached to those. This volume houses docker, var, and logs. |
 
+## Usage by Parameters
+The command demonstrated how to use the custom parameters to build eks_version 1.21 in HK(ap-east-1) region.
+```
+make build PACKER_FILE=amazon-eks-node-al2.json eks_version=1.21  VPC_ID=<must be your hk region VPC> SUBNET_ID=<must be your hk region public subnet> AWS_REGION=ap-east-1 source_ami_owner=800184023465
+```
+
 ### Using the AMI
 
 The AMI can be used with [self-managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/worker.html) and [managed node groups](https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html) within EKS. The AMIs built in this repository use the same [bootstrap script](https://github.com/awslabs/amazon-eks-ami/blob/master/files/bootstrap.sh) used in the EKS Optimized AMI. To join the cluster, run the following command on boot:

--- a/scripts/al2/boilerplate.sh
+++ b/scripts/al2/boilerplate.sh
@@ -16,6 +16,10 @@ yum install -y parted system-lsb-core
 # enable the epel release
 amazon-linux-extras install epel -y
 
+# start docker, refer to the issue: https://github.com/aws-samples/amazon-eks-custom-amis/issues/36
+echo "start docker"
+systemctl start docker
+
 echo "ensure secondary disk is mounted to proper locations"
 partition_disks /dev/nvme2n1
 
@@ -23,6 +27,10 @@ echo "configuring /etc/environment"
 configure_http_proxy
 configure_docker_environment
 configure_kubelet_environment
+
+# stop docker before reboot
+echo "stop docker"
+systemctl stop docker
 
 echo "rebooting the instance"
 reboot

--- a/scripts/shared/cis-docker.sh
+++ b/scripts/shared/cis-docker.sh
@@ -20,7 +20,8 @@ echo "1.1.1 - ensure the container host has been hardened"
 echo "[not scored] - 1.1.1 ensure the container host has been hardened"
 
 echo "1.1.2 - ensure that the version of Docker is up to date"
-docker version
+# docker version 
+# comment this line is because the base AMI shall install the corresponding docker version
 
 echo "1.2.1 - ensure a separate partition for containers has been created"
 grep '/var/lib/docker\s' /proc/mounts


### PR DESCRIPTION
Fix issue #36, tested on eks version 1.19 and 1.21, and expose the source_ami_owner variable, so that the repo can be used for different regions

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
