### PR TITLE
Fix the AMI's are not able to connect to the EKS cluster

### DIFF
--- a/scripts/shared/eks.sh
+++ b/scripts/shared/eks.sh
@@ -135,7 +135,7 @@ systemctl daemon-reload && systemctl disable kubelet
 
 mkdir -p /etc/eks
 curl -sL -o /etc/eks/eni-max-pods.txt https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/files/eni-max-pods.txt
-curl -sL -o /etc/eks/bootstrap.sh https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/files/bootstrap.sh
+curl -sL -o /etc/eks/bootstrap.sh https://raw.githubusercontent.com/awslabs/amazon-eks-ami/ff309f19/files/bootstrap.sh
 chmod +x /etc/eks/bootstrap.sh
 
 ################################################################################


### PR DESCRIPTION
The AMI's generated by this repo are not able to be assigned to the EKS cluster due to there is significant change in "awslabs/amazon-eks-ami" - bootstrap.sh script in particular - which is dependancy for this project: https://github.com/dushevadnqka/amazon-eks-custom-amis/blob/main/scripts/shared/eks.sh#L138.
The change - breaker could be reviewed here: https://github.com/awslabs/amazon-eks-ami/commit/af6a02dec0171bae7a20605e1427ba4d9e051bc2#diff-049390d14bc3ea2d7882ff0f108e2802ad9b043336c5fa637e93581d9a7fdfc2

*Issue #, if available:*

#39 

*Description of changes:*

What is offered here is just a temporary reverse to the previous commit - before the shown above change.
The commit hash I offer (https://raw.githubusercontent.com/awslabs/amazon-eks-ami/ff309f19/files/bootstrap.sh) is visible from the attached image:

<img width="1055" alt="Screenshot 2021-08-19 at 12 14 59" src="https://user-images.githubusercontent.com/6117336/130046580-750e40c0-7e72-41ec-8521-152e39fb363b.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
