### PR TITLE
conditional copy command added

### DIFF
--- a/files/functions.sh
+++ b/files/functions.sh
@@ -346,7 +346,7 @@ migrate_and_mount_disk() {
     if [ -d "${folder_path}" ]; then
         mkdir -p ${temp_path}
         mount ${disk_name} ${temp_path}
-        cp -Rax ${folder_path}/* ${temp_path}
+        [ "$(ls -A ${folder_path})" ] && cp -Rax ${folder_path}/* ${temp_path}  || echo "Nothing to copy from ${folder_path} dir"
         mv ${folder_path} ${old_path}
         umount ${disk_name}
     fi


### PR DESCRIPTION
*Issue #41 *

*Description of changes:*
This issue occurs when there is no file/dir in ```/var/lib/docker/``` . This change will check if that dir contains something before firing ```cp``` command. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
