### PR TITLE
update cis al2 benchmark to v2.0.0

### DIFF
--- a/scripts/al2/boilerplate.sh
+++ b/scripts/al2/boilerplate.sh
@@ -16,6 +16,9 @@ yum install -y parted system-lsb-core
 # enable the epel release
 amazon-linux-extras install epel -y
 
+echo "start docker"
+systemctl start docker
+
 echo "ensure secondary disk is mounted to proper locations"
 partition_disks /dev/nvme2n1
 
@@ -23,6 +26,9 @@ echo "configuring /etc/environment"
 configure_http_proxy
 configure_docker_environment
 configure_kubelet_environment
+
+echo "stop docker"
+systemctl stop docker
 
 echo "rebooting the instance"
 reboot

--- a/scripts/shared/cis-docker.sh
+++ b/scripts/shared/cis-docker.sh
@@ -20,7 +20,7 @@ echo "1.1.1 - ensure the container host has been hardened"
 echo "[not scored] - 1.1.1 ensure the container host has been hardened"
 
 echo "1.1.2 - ensure that the version of Docker is up to date"
-docker version
+yum -y update docker
 
 echo "1.2.1 - ensure a separate partition for containers has been created"
 grep '/var/lib/docker\s' /proc/mounts


### PR DESCRIPTION
## Description
- Update Amazon Linux 2 CIS Benchmark to v2.0.0

## Motivation and Context
To ensure that AL2 AMI is CIS compliant with the latest version.

## How Has This Been Tested?
- Rebuilt the AMI and it succeeded without any errors
- Provisioned a worker node from this AMI and it worked properly

## Screenshots (if appropriate):

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
