### PR TITLE
fix: Invalid JSON in docker daemon config

### DIFF
--- a/scripts/cis-docker.sh
+++ b/scripts/cis-docker.sh
@@ -64,7 +64,7 @@ cat > /etc/docker/daemon.json <<EOF
       "Hard": 200,
       "Soft": 100
     },
-    "nofile": {
+    "nproc": {
       "Name": "nproc",
       "Hard": 2048,
       "Soft": 1024


### PR DESCRIPTION
## Description
The JSON contains two identical keys in the same object but they should be different.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
