### PR TITLE
new variables 'associate_public_ip_address' and 'target_ami_name_prefix'

### DIFF
--- a/amazon-eks-al2.pkr.hcl
+++ b/amazon-eks-al2.pkr.hcl
@@ -1,7 +1,7 @@
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
 
-  target_ami_name = "${var.ami_name_prefix}-${var.eks_version}-${local.timestamp}"
+  target_ami_name = "${var.target_ami_name_prefix}-${var.eks_version}-${local.timestamp}"
 }
 
 data "amazon-ami" "this" {
@@ -54,10 +54,12 @@ source "amazon-ebs" "this" {
     Name = local.target_ami_name
   }
 
-  source_ami   = data.amazon-ami.this.id
-  ssh_pty      = true
-  ssh_username = var.source_ami_ssh_user
-  subnet_id    = var.subnet_id
+  source_ami                  = data.amazon-ami.this.id
+  ssh_pty                     = true
+  ssh_username                = var.source_ami_ssh_user
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = var.associate_public_ip_address
+  
 
   tags = {
     os_version        = "Amazon Linux 2"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -77,7 +77,19 @@ variable "instance_type" {
 }
 
 variable "ami_name_prefix" {
-  description = "The prefix to use when creating the AMI name. i.e. - `<ami_name_prefix>-<eks_version>-<timestamp>"
+  description = "The prefix identifying the source AMI to use when creating the AMI. i.e. - `<ami_name_prefix>-<eks_version>-<timestamp>"
   type        = string
   default     = "amazon-eks-node"
+}
+
+variable "associate_public_ip_address" {
+  description = "If using a non-default VPC, public IP addresses are not provided by default. If this is true, your new instance will get a Public IP."
+  type        = string
+  default     = null
+}
+
+variable "target_ami_name_prefix" {
+  description = "The prefix to use when creating the AMI name. i.e. - `<target_ami_name_prefix>-<eks_version>-<timestamp>"
+  type        = string
+  default     = "custom-eks-node"
 }


### PR DESCRIPTION
## Description
Two new variables added to Packer config. 

## Motivation and Context
Fixes [issue 64](https://github.com/aws-samples/amazon-eks-custom-amis/issues/64)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These changes were tested by running against an AWS account using a non-default VPC and a public subnet that was not configured to auto-assign public IPs. 

## Screenshots (if appropriate):

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
